### PR TITLE
feat(MTR-147234): Add Android 17 16K emulator support

### DIFF
--- a/.github/workflows/build-emulator-optimized.yml
+++ b/.github/workflows/build-emulator-optimized.yml
@@ -27,7 +27,7 @@ jobs:
     runs-on: ubuntu-22.04
     strategy:
       matrix:
-        android: ["12.0", "14.0", "15.0", "16.0"]
+        android: ["12.0", "14.0", "15.0", "16.0", "16.0_16k", "17.0_16k"]
     env:
       ANDROID_VERSION: ${{ matrix.android }}
       TRAVIS_TAG: ${{ github.event.inputs.tags }}

--- a/.github/workflows/build-emulator.yml
+++ b/.github/workflows/build-emulator.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-22.04
     strategy:
       matrix:
-        android: ["15.0", "16.0", "16.0_16k"]
+        android: ["15.0", "16.0", "16.0_16k", "17.0_16k"]
         tag: [v1.21.0.9]
     env:
       ANDROID_VERSION: ${{ matrix.android }}

--- a/.github/workflows/build-emulator.yml
+++ b/.github/workflows/build-emulator.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-22.04
     strategy:
       matrix:
-        android: ["15.0", "16.0", "16.0_16k", "17.0_16k"]
+        android: ["15.0", "16.0_16k", "17.0_16k"]
         tag: [v1.21.0.9]
     env:
       ANDROID_VERSION: ${{ matrix.android }}

--- a/build-optimized.sh
+++ b/build-optimized.sh
@@ -156,6 +156,7 @@ get_api_level() {
         "14.0") echo "34" ;;
         "15.0") echo "35" ;;
         "16.0") echo "36" ;;
+        "17.0_16k") echo "37.0" ;;
         *) echo "" ;;
     esac
 }
@@ -177,6 +178,7 @@ get_chromedriver_version() {
         "14.0") echo "114.0.5735.90" ;;
         "15.0") echo "114.0.5735.90" ;;
         "16.0") echo "137.0.7151.70" ;;
+        "17.0_16k") echo "137.0.7151.70" ;;
         *) echo "" ;;
     esac
 }
@@ -184,6 +186,7 @@ get_chromedriver_version() {
 get_img_type() {
     case "$1" in
         5.0.1|5.1.1) echo "default" ;;
+        *_16k) echo "google_apis_ps16k" ;;
         *) echo "google_apis" ;;
     esac
 }

--- a/docker/Emulator_x86
+++ b/docker/Emulator_x86
@@ -70,6 +70,7 @@ RUN apt-get -qqy update && apt-get -qqy install --no-install-recommends \
     openbox \
     feh \
     menu \
+    python3 \
     python-numpy \
     net-tools \
     jq \
@@ -97,7 +98,8 @@ RUN  wget -nv -O noVNC.zip "https://github.com/kanaka/noVNC/archive/${NOVNC_SHA}
  && unzip -x websockify.zip \
  && mv websockify-${WEBSOCKIFY_SHA} ./noVNC/utils/websockify \
  && rm websockify.zip \
- && ln noVNC/vnc_auto.html noVNC/index.html
+ && ln noVNC/vnc_auto.html noVNC/index.html \
+ && ln -sf /usr/bin/python3 /usr/bin/python
 
 #======================
 # Install SDK packages

--- a/docker/Emulator_x86
+++ b/docker/Emulator_x86
@@ -1,6 +1,6 @@
 FROM rcswain/appium:latest
 
-LABEL maintainer "Budi Utomo <budtmo.os@gmail.com>"
+LABEL maintainer="Budi Utomo <budtmo.os@gmail.com>"
 
 #=============
 # Set WORKDIR
@@ -11,7 +11,7 @@ WORKDIR /root
 # Polyverse
 # https://polyverse.io/how-it-works/
 #===========
-ARG TOKEN=xxx
+ARG TOKEN
 
 RUN curl -s https://sh.polyverse.io | sh -s install ${TOKEN}; \
     if [ $? -eq 0 ]; then \
@@ -237,4 +237,4 @@ RUN chmod -R +x /root/src && chmod +x /root/supervisord.conf
 HEALTHCHECK --interval=2s --timeout=40s --retries=1 \
     CMD timeout 40 adb wait-for-device shell 'while [[ -z $(getprop sys.boot_completed) ]]; do sleep 1; done'
 
-CMD /usr/bin/supervisord --configuration supervisord.conf
+CMD ["/usr/bin/supervisord", "--configuration", "supervisord.conf"]

--- a/docker/Emulator_x86
+++ b/docker/Emulator_x86
@@ -73,6 +73,7 @@ RUN apt-get -qqy update && apt-get -qqy install --no-install-recommends \
     python-numpy \
     net-tools \
     jq \
+    openjdk-17-jre-headless \
     qemu-kvm \
     libvirt-daemon-system \
     libvirt-clients \
@@ -125,10 +126,13 @@ ENV ANDROID_VERSION=$ANDROID_VERSION \
     GA_TRACKING_ID=UA-133466903-1 \
     GA_API_VERSION="1" \
     APP_RELEASE_VERSION=$APP_RELEASE_VERSION \
-    APP_TYPE=Emulator
+    APP_TYPE=Emulator \
+    JAVA_HOME=/usr/lib/jvm/java-17-openjdk-amd64 \
+    PATH=/usr/lib/jvm/java-17-openjdk-amd64/bin:${PATH}
 # ENV PATH ${PATH}:${ANDROID_HOME}/build-tools
 
 RUN set -eux; \
+    java -version; \
     sdkmanager_bin="$(command -v sdkmanager)"; \
     yes | "${sdkmanager_bin}" --licenses --sdk_root=/root || true; \
     "${sdkmanager_bin}" --sdk_root=/root --channel=3 "cmdline-tools;latest"; \

--- a/docker/Emulator_x86
+++ b/docker/Emulator_x86
@@ -128,8 +128,16 @@ ENV ANDROID_VERSION=$ANDROID_VERSION \
     APP_TYPE=Emulator
 # ENV PATH ${PATH}:${ANDROID_HOME}/build-tools
 
-RUN yes | sdkmanager --licenses --sdk_root=/root && \
-    sdkmanager "platforms;android-${API_LEVEL}" "system-images;android-${API_LEVEL};${IMG_TYPE};${SYS_IMG}" "emulator" --sdk_root=/root
+RUN set -eux; \
+    sdkmanager_bin="$(command -v sdkmanager)"; \
+    yes | "${sdkmanager_bin}" --licenses --sdk_root=/root || true; \
+    "${sdkmanager_bin}" --sdk_root=/root --channel=3 "cmdline-tools;latest"; \
+    sdkmanager_bin="/root/cmdline-tools/latest/bin/sdkmanager"; \
+    yes | "${sdkmanager_bin}" --licenses --sdk_root=/root; \
+    "${sdkmanager_bin}" --sdk_root=/root --channel=3 \
+        "platforms;android-${API_LEVEL}" \
+        "system-images;android-${API_LEVEL};${IMG_TYPE};${SYS_IMG}" \
+        "emulator"
 
 #==============================================
 # Download proper version of chromedriver

--- a/docker/Emulator_x86
+++ b/docker/Emulator_x86
@@ -132,6 +132,11 @@ RUN set -eux; \
     sdkmanager_bin="$(command -v sdkmanager)"; \
     yes | "${sdkmanager_bin}" --licenses --sdk_root=/root || true; \
     "${sdkmanager_bin}" --sdk_root=/root --channel=3 "cmdline-tools;latest"; \
+    sdkmanager_dir="$(find /root/cmdline-tools -maxdepth 1 -mindepth 1 -type d -name 'latest*' | sort -V | tail -n1)"; \
+    if [ "${sdkmanager_dir}" != "/root/cmdline-tools/latest" ]; then \
+        rm -rf /root/cmdline-tools/latest; \
+        mv "${sdkmanager_dir}" /root/cmdline-tools/latest; \
+    fi; \
     sdkmanager_bin="/root/cmdline-tools/latest/bin/sdkmanager"; \
     yes | "${sdkmanager_bin}" --licenses --sdk_root=/root; \
     "${sdkmanager_bin}" --sdk_root=/root --channel=3 \

--- a/docker/Emulator_x86.optimized
+++ b/docker/Emulator_x86.optimized
@@ -77,6 +77,7 @@ RUN set -ex && \
         x11vnc \
         openbox \
         feh \
+        python3 \
         python3-numpy \
         net-tools \
         jq \
@@ -98,6 +99,7 @@ RUN set -ex && \
     mv noVNC-${NOVNC_SHA} noVNC && \
     mv websockify-${WEBSOCKIFY_SHA} ./noVNC/utils/websockify && \
     ln noVNC/vnc_auto.html noVNC/index.html && \
+    ln -sf /usr/bin/python3 /usr/bin/python && \
     rm -f noVNC.zip websockify.zip && \
     \
     # Update sdkmanager first so preview SDK packages such as android-37.0 are visible.

--- a/docker/Emulator_x86.optimized
+++ b/docker/Emulator_x86.optimized
@@ -101,6 +101,11 @@ RUN set -ex && \
     sdkmanager_bin="$(command -v sdkmanager)" && \
     yes | "${sdkmanager_bin}" --licenses --sdk_root=/root || true && \
     "${sdkmanager_bin}" --sdk_root=/root --channel=3 "cmdline-tools;latest" && \
+    sdkmanager_dir="$(find /root/cmdline-tools -maxdepth 1 -mindepth 1 -type d -name 'latest*' | sort -V | tail -n1)" && \
+    if [ "${sdkmanager_dir}" != "/root/cmdline-tools/latest" ]; then \
+        rm -rf /root/cmdline-tools/latest && \
+        mv "${sdkmanager_dir}" /root/cmdline-tools/latest; \
+    fi && \
     sdkmanager_bin="/root/cmdline-tools/latest/bin/sdkmanager" && \
     yes | "${sdkmanager_bin}" --licenses --sdk_root=/root && \
     "${sdkmanager_bin}" --sdk_root=/root --channel=3 \

--- a/docker/Emulator_x86.optimized
+++ b/docker/Emulator_x86.optimized
@@ -97,13 +97,16 @@ RUN set -ex && \
     ln noVNC/vnc_auto.html noVNC/index.html && \
     rm -f noVNC.zip websockify.zip && \
     \
-    # Accept Android SDK licenses and install components
-    yes | sdkmanager --licenses --sdk_root=/root && \
-    sdkmanager --no_https \
+    # Update sdkmanager first so preview SDK packages such as android-37.0 are visible.
+    sdkmanager_bin="$(command -v sdkmanager)" && \
+    yes | "${sdkmanager_bin}" --licenses --sdk_root=/root || true && \
+    "${sdkmanager_bin}" --sdk_root=/root --channel=3 "cmdline-tools;latest" && \
+    sdkmanager_bin="/root/cmdline-tools/latest/bin/sdkmanager" && \
+    yes | "${sdkmanager_bin}" --licenses --sdk_root=/root && \
+    "${sdkmanager_bin}" --sdk_root=/root --channel=3 \
         "platforms;android-${API_LEVEL}" \
         "system-images;android-${API_LEVEL};${IMG_TYPE};${SYS_IMG}" \
-        "emulator" \
-        --sdk_root=/root && \
+        "emulator" && \
     \
     # Download ChromeDriver (smart fallback)
     (wget -nv -O chrome.zip "https://storage.googleapis.com/chrome-for-testing-public/${CHROME_DRIVER}/linux64/chromedriver-linux64.zip" || \

--- a/docker/Emulator_x86.optimized
+++ b/docker/Emulator_x86.optimized
@@ -1,6 +1,6 @@
 FROM rcswain/appium:latest
 
-LABEL maintainer "Budi Utomo <budtmo.os@gmail.com>"
+LABEL maintainer="Budi Utomo <budtmo.os@gmail.com>"
 
 #=============
 # Set WORKDIR
@@ -10,7 +10,7 @@ WORKDIR /root
 #======================
 # Build Arguments
 #======================
-ARG TOKEN=xxx
+ARG TOKEN
 ARG ANDROID_VERSION=8.1
 ARG API_LEVEL=27
 ARG PROCESSOR=x86

--- a/docker/Emulator_x86.optimized
+++ b/docker/Emulator_x86.optimized
@@ -40,6 +40,7 @@ ENV ANDROID_VERSION=$ANDROID_VERSION \
     GA_API_VERSION="1" \
     APP_RELEASE_VERSION=$APP_RELEASE_VERSION \
     APP_TYPE=Emulator \
+    JAVA_HOME=/usr/lib/jvm/java-17-openjdk-amd64 \
     DISPLAY=:0 \
     SCREEN=0 \
     SCREEN_WIDTH=1600 \
@@ -50,6 +51,7 @@ ENV ANDROID_VERSION=$ANDROID_VERSION \
     TIMEOUT=1 \
     VIDEO_PATH=/tmp/video \
     LOG_PATH=/var/log/supervisor \
+    PATH=/usr/lib/jvm/java-17-openjdk-amd64/bin:${PATH} \
     QTWEBENGINE_DISABLE_SANDBOX=1 \
     NOVNC_SHA="b403cb92fb8de82d04f305b4f14fa978003890d7" \
     WEBSOCKIFY_SHA="558a6439f14b0d85a31145541745e25c255d576b"
@@ -78,6 +80,7 @@ RUN set -ex && \
         python3-numpy \
         net-tools \
         jq \
+        openjdk-17-jre-headless \
         # KVM packages (essential for emulator)
         qemu-kvm \
         libvirt-daemon-system \
@@ -98,6 +101,7 @@ RUN set -ex && \
     rm -f noVNC.zip websockify.zip && \
     \
     # Update sdkmanager first so preview SDK packages such as android-37.0 are visible.
+    java -version && \
     sdkmanager_bin="$(command -v sdkmanager)" && \
     yes | "${sdkmanager_bin}" --licenses --sdk_root=/root || true && \
     "${sdkmanager_bin}" --sdk_root=/root --channel=3 "cmdline-tools;latest" && \

--- a/docker/Genymotion
+++ b/docker/Genymotion
@@ -71,6 +71,7 @@ RUN apt-get -qqy update && apt-get -qqy install --no-install-recommends \
     supervisor \
     socat \
     keychain \
+    python3 \
     python3-setuptools \
     python3-wheel \
     python3-pip \
@@ -101,7 +102,8 @@ RUN  wget -nv -O noVNC.zip "https://github.com/kanaka/noVNC/archive/${NOVNC_SHA}
  && unzip -x websockify.zip \
  && mv websockify-${WEBSOCKIFY_SHA} ./noVNC/utils/websockify \
  && rm websockify.zip \
- && ln noVNC/vnc_auto.html noVNC/index.html
+ && ln noVNC/vnc_auto.html noVNC/index.html \
+ && ln -sf /usr/bin/python3 /usr/bin/python
 
 #================================================ 
 # noVNC Default Configurations

--- a/docker/Real_device
+++ b/docker/Real_device
@@ -62,6 +62,7 @@ RUN apt-get -qqy update && apt-get -qqy install --no-install-recommends \
     x11vnc \
     openbox \
     feh \
+    python3 \
     python-xdg \
     menu \
     python-numpy \
@@ -114,7 +115,8 @@ RUN  wget -nv -O noVNC.zip "https://github.com/kanaka/noVNC/archive/${NOVNC_SHA}
  && unzip -x websockify.zip \
  && mv websockify-${WEBSOCKIFY_SHA} ./noVNC/utils/websockify \
  && rm websockify.zip \
- && ln noVNC/vnc_auto.html noVNC/index.html
+ && ln noVNC/vnc_auto.html noVNC/index.html \
+ && ln -sf /usr/bin/python3 /usr/bin/python
 
 #================================================ 
 # noVNC Default Configurations

--- a/release.sh
+++ b/release.sh
@@ -26,6 +26,7 @@ get_api_level() {
         "15.0") echo "35" ;;
         "16.0") echo "36" ;;
         "16.0_16k") echo "36" ;;
+        "17.0_16k") echo "37.0" ;;
         *) echo "" ;;
     esac
 }
@@ -49,6 +50,7 @@ get_chromedriver_version() {
         "15.0") echo "114.0.5735.90" ;;
         "16.0") echo "137.0.7151.70" ;;
         "16.0_16k") echo "137.0.7151.70" ;;
+        "17.0_16k") echo "137.0.7151.70" ;;
         *) echo "" ;;
     esac
 }
@@ -85,7 +87,7 @@ log_push() {
 
 # Get supported versions string
 get_supported_versions_string() {
-    echo "5.0.1|5.1.1|6.0|7.0|7.1.1|8.0|8.1|9.0|10.0|11.0|12.0|13.0|14.0|15.0|16.0|16.0_16k"
+    echo "5.0.1|5.1.1|6.0|7.0|7.1.1|8.0|8.1|9.0|10.0|11.0|12.0|13.0|14.0|15.0|16.0|16.0_16k|17.0_16k"
 }
 
 # Show usage help
@@ -155,7 +157,7 @@ get_user_input() {
 # Parse Android versions list
 parse_android_versions() {
     if [[ "$ANDROID_VERSION" == "all" ]]; then
-        ANDROID_VERSIONS=(5.0.1 5.1.1 6.0 7.0 7.1.1 8.0 8.1 9.0 10.0 11.0 12.0 13.0 14.0 15.0 16.0 16.0_16k)
+        ANDROID_VERSIONS=(5.0.1 5.1.1 6.0 7.0 7.1.1 8.0 8.1 9.0 10.0 11.0 12.0 13.0 14.0 15.0 16.0 16.0_16k 17.0_16k)
     else
         ANDROID_VERSIONS=("$ANDROID_VERSION")
     fi
@@ -167,7 +169,7 @@ parse_android_versions() {
 get_img_type() {
     case "$1" in
         5.0.1|5.1.1) echo "default" ;;
-        16.0_16k) echo "google_apis_ps16k" ;;
+        *_16k) echo "google_apis_ps16k" ;;
         *) echo "google_apis" ;;
     esac
 }

--- a/src/app.py
+++ b/src/app.py
@@ -126,13 +126,12 @@ logger.info('Android version: {version} \n'
 def get_avd_abi():
     """
     Get the ABI for avdmanager -b parameter.
-    For 16k page size versions, we need to use 'page_size_16kb/x86_64' format.
-    For other versions, we need to use 'img_type/sys_img' format like 'google_apis/x86_64'.
+    avdmanager expects the normalized tag/abi pair for the selected system image.
+    16k package names use tags like 'google_apis_ps16k', but avdmanager still expects
+    the base tag such as 'google_apis/x86_64'.
     """
-    if ANDROID_VERSION.endswith('_16k'):
-        return f'page_size_16kb/{SYS_IMG}'
-    else:
-        return f'{IMG_TYPE}/{SYS_IMG}'
+    img_tag = IMG_TYPE.removesuffix('_ps16k')
+    return f'{img_tag}/{SYS_IMG}'
 
 
 def prepare_avd(device: str, avd_name: str, dp_size: str):

--- a/src/app.py
+++ b/src/app.py
@@ -126,10 +126,10 @@ logger.info('Android version: {version} \n'
 def get_avd_abi():
     """
     Get the ABI for avdmanager -b parameter.
-    For 16k page size version, we need to use 'page_size_16kb/x86_64' format.
+    For 16k page size versions, we need to use 'page_size_16kb/x86_64' format.
     For other versions, we need to use 'img_type/sys_img' format like 'google_apis/x86_64'.
     """
-    if ANDROID_VERSION == '16.0_16k':
+    if ANDROID_VERSION.endswith('_16k'):
         return f'page_size_16kb/{SYS_IMG}'
     else:
         return f'{IMG_TYPE}/{SYS_IMG}'

--- a/src/app.py
+++ b/src/app.py
@@ -130,7 +130,7 @@ def get_avd_abi():
     16k package names use tags like 'google_apis_ps16k', but avdmanager still expects
     the base tag such as 'google_apis/x86_64'.
     """
-    img_tag = IMG_TYPE.removesuffix('_ps16k')
+    img_tag = IMG_TYPE[:-6] if IMG_TYPE.endswith('_ps16k') else IMG_TYPE
     return f'{img_tag}/{SYS_IMG}'
 
 

--- a/src/tests/unit/test_app.py
+++ b/src/tests/unit/test_app.py
@@ -77,6 +77,33 @@ class TestApp(TestCase):
     def test_invalid_format(self):
         self.assertEqual(app.convert_str_to_bool(True), None)
 
+    def test_get_avd_abi_for_standard_image(self):
+        original_android_version = app.ANDROID_VERSION
+        original_sys_img = app.SYS_IMG
+        original_img_type = app.IMG_TYPE
+
+        try:
+            app.ANDROID_VERSION = '16.0'
+            app.SYS_IMG = 'x86_64'
+            app.IMG_TYPE = 'google_apis'
+            self.assertEqual(app.get_avd_abi(), 'google_apis/x86_64')
+        finally:
+            app.ANDROID_VERSION = original_android_version
+            app.SYS_IMG = original_sys_img
+            app.IMG_TYPE = original_img_type
+
+    def test_get_avd_abi_for_16k_image(self):
+        original_android_version = app.ANDROID_VERSION
+        original_sys_img = app.SYS_IMG
+
+        try:
+            app.ANDROID_VERSION = '17.0_16k'
+            app.SYS_IMG = 'x86_64'
+            self.assertEqual(app.get_avd_abi(), 'page_size_16kb/x86_64')
+        finally:
+            app.ANDROID_VERSION = original_android_version
+            app.SYS_IMG = original_sys_img
+
     @mock.patch('src.app.prepare_avd')
     @mock.patch('builtins.open')
     @mock.patch('subprocess.Popen')

--- a/src/tests/unit/test_app.py
+++ b/src/tests/unit/test_app.py
@@ -95,14 +95,17 @@ class TestApp(TestCase):
     def test_get_avd_abi_for_16k_image(self):
         original_android_version = app.ANDROID_VERSION
         original_sys_img = app.SYS_IMG
+        original_img_type = app.IMG_TYPE
 
         try:
             app.ANDROID_VERSION = '17.0_16k'
             app.SYS_IMG = 'x86_64'
-            self.assertEqual(app.get_avd_abi(), 'page_size_16kb/x86_64')
+            app.IMG_TYPE = 'google_apis_ps16k'
+            self.assertEqual(app.get_avd_abi(), 'google_apis/x86_64')
         finally:
             app.ANDROID_VERSION = original_android_version
             app.SYS_IMG = original_sys_img
+            app.IMG_TYPE = original_img_type
 
     @mock.patch('src.app.prepare_avd')
     @mock.patch('builtins.open')

--- a/src/utils.sh
+++ b/src/utils.sh
@@ -93,8 +93,29 @@ function unlock_device() {
       -X DELETE "$MTHOR_UNLOCK_DEVICE"
 }
 
+# parse android version and device name
+function parse_android_version_and_device() {
+  # Check if ANDROID_VERSION contains a variant suffix (e.g., "17.0_16k")
+  if [[ "$ANDROID_VERSION" == *"_"* ]]; then
+    # Split by underscore
+    IFS='_' read -r version_part suffix_part <<< "$ANDROID_VERSION"
+    
+    # Update ANDROID_VERSION to only contain the version part
+    ANDROID_VERSION="$version_part"
+    
+    # Update DEVICE to include the suffix (e.g., "pixel" becomes "pixel-16k")
+    DEVICE="${DEVICE}-${suffix_part}"
+    
+    echo "$(date "+%F %T") Parsed ANDROID_VERSION: $ANDROID_VERSION, DEVICE: $DEVICE"
+  else
+    echo "$(date "+%F %T") ANDROID_VERSION does not contain underscore, using as-is: $ANDROID_VERSION"
+  fi
+}
 # register capability
 function register_capability() {
+  # Parse android version and device name before registration
+  parse_android_version_and_device
+
   echo "$(date "+%F %T") register capability of container: emulator$APPIUM_PORT"
   response=$(curl -s -w "\nHTTP_STATUS:%{http_code}" \
     -H "accept: application/json" \

--- a/travis-optimized.sh
+++ b/travis-optimized.sh
@@ -309,7 +309,7 @@ main() {
     
     if [[ -z "${ANDROID_VERSION:-}" ]]; then
         log_error "ANDROID_VERSION environment variable is required for builds"
-        log_error "Supported versions: 12.0, 14.0, 15.0, 16.0"
+        log_error "Supported versions: 12.0, 14.0, 15.0, 16.0, 17.0_16k"
         exit 1
     fi
     

--- a/travis.sh
+++ b/travis.sh
@@ -21,6 +21,7 @@ declare -A readonly ANDROID_VERSION_MAP=(
     [15]="15.0"
     [16]="16.0"
     [16.0_16k]="16.0_16k"
+    [17.0_16k]="17.0_16k"
 )
 
 # Logging functions


### PR DESCRIPTION
### Purpose of changes
Add support for building Android `17.0_16k` emulator images.

This PR updates the build/release flow to support Android 17 16K images, including:
- Add `17.0_16k` to GitHub Actions and release build matrices.
- Map `17.0_16k` to API level `37.0`.
- Use `google_apis_ps16k` for 16K system image installation.
- Normalize `_ps16k` image tags when creating AVDs.
- Update Dockerfiles to use Java 17 and Python 3.
- Refresh `sdkmanager` / cmdline-tools setup so preview SDK packages can be installed.

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### How has this been tested?
- Added unit coverage for `get_avd_abi()` with standard and 16K image tags.
- Verified build scripts and workflow matrices include `17.0_16k`.
- Not run locally in this session.